### PR TITLE
Revert "Base type of IStoredTableDataSet changed from IQueryable<IRow> to IEnumerable<IRow>"

### DIFF
--- a/src/Pure.RelationalSchema.Storage.Abstractions/IStoredTableDataSet.cs
+++ b/src/Pure.RelationalSchema.Storage.Abstractions/IStoredTableDataSet.cs
@@ -2,7 +2,7 @@ using Pure.RelationalSchema.Abstractions.Table;
 
 namespace Pure.RelationalSchema.Storage.Abstractions;
 
-public interface IStoredTableDataSet : IEnumerable<IRow>, IAsyncEnumerable<IRow>
+public interface IStoredTableDataSet : IQueryable<IRow>, IAsyncEnumerable<IRow>
 {
     ITable TableSchema { get; }
 }


### PR DESCRIPTION
This reverts commit c5d3c1f69935df88a389c492dc76d64c873d2518.