### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.RelationalSchema.Storage.Abstractions/Pure.RelationalSchema.Storage.Abstractions.csproj
+++ b/src/Pure.RelationalSchema.Storage.Abstractions/Pure.RelationalSchema.Storage.Abstractions.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.1.0-preview.4.1.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Storage.Abstractions</PackageId>


### PR DESCRIPTION
Closes #50

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.